### PR TITLE
feat: CLI multi-device hierarchy and device registry

### DIFF
--- a/.idea/f-cli-multi-device.md
+++ b/.idea/f-cli-multi-device.md
@@ -1,0 +1,9 @@
+# CLI Multi-Device Feature
+
+Track progress for the CLI hierarchy refactor.
+
+## Planned work
+- [ ] Refactor `src/cli/index.ts` — support `lumina bulb <name> <action>` argument order
+- [ ] Add `--all` flag for bulk operations
+- [ ] Implement local device registry in `config/devices.json`
+- [ ] Add `inquirer` for interactive disambiguation

--- a/README.md
+++ b/README.md
@@ -8,10 +8,10 @@
 ## Architecture Overview
 
 ```
-     ┌─────────────────────────────┐            ┌─────────────────────┐
-     │             CLI             │            │      Telegram       │
-     │   parse args → detect mode  │            │      WhatsApp       │
-     └────────┬─────────────────┬──┘            └──────────┬──────────┘
+     ┌─────────────────────────────┐            ┌──────────────────────────┐
+     │             CLI             │            │ Telegram | WhatsApp | WS │
+     │   parse args → detect mode  │            │      Cron Scheduler      │
+     └────────┬─────────────────┬──┘            └──────────┬───────────────┘
               │                 |                          │
               │  bulb on        │ bulb -m "light on karna" │
               │                 │                          │
@@ -51,12 +51,12 @@
 
 |              | Direct lane          | AI (message) lane               |
 | ------------ | -------------------- | ------------------------------- |
-| Entry        | `bulb on`            | `bulb -m "dim the lights"`      |
+| Entry        | `lumina-cli bulb on`    | `lumina-cli bulb -m "dim the lights"`|
 | Parsed by    | Command parser       | Message router → Ollama         |
 | Intelligence | None — exact command | LLM decides which tools to call |
 | Latency      | ~100ms               | ~1–3s (LLM round-trip)          |
 | Multi-step   | No                   | Yes — chains multiple tools     |
-| Sources      | CLI only             | CLI `-m`, Telegram, WhatsApp    |
+| Sources      | CLI only             | CLI `-m`, Telegram, WhatsApp, WebSocket |
 
 ---
 
@@ -64,10 +64,10 @@
 
 ```bash
 # Direct lane — fast, exact
-bulb on | off | brightness 70 | scene movie | status
+lumina-cli bulb on | off | brightness 70 | scene movie | status
 
 # AI lane — natural language
-bulb -m "dim to 30 percent and make it warm"
+lumina-cli bulb -m "dim to 30 percent and make it warm"
 ```
 
 ---
@@ -76,15 +76,19 @@ bulb -m "dim to 30 percent and make it warm"
 
 ```
 src/
-  index.ts          # CLI entry — mode detection
+  cli/
+    index.ts        # CLI entry — mode detection
   agent.ts          # Ollama chat loop + tool dispatch
   types.ts          # Shared interfaces
-  tools/            # Tool schemas (definitions.ts) + dispatcher (executor.ts)
-  integrations/     # Message router, Telegram & WhatsApp (planned)
+  model/
+    tools/          # Tool schemas (definitions.ts) + dispatcher (executor.ts)
+  integrations/     # Message router, Telegram, WhatsApp, WebSocket listeners
+  service/          # Cron scheduler and long-running services
 scripts/
   bulb_control.py   # TinyTuya LAN controller
 config/
   scenes.json       # Scene presets
+  automations.json  # Scheduled automations
 ```
 
 ---
@@ -94,8 +98,8 @@ config/
 - **Phase 1 — IoT control** ✅ Bulb paired, TinyTuya verified
 - **Phase 2 — CLI direct lane** ✅ Arg parsing, command execution
 - **Phase 3 — AI message lane** ✅ Ollama loop, multi-tool chaining, `-m` flag
-- **Phase 4 — Telegram & WhatsApp** 🔜 Bot listeners, message routing, per-user history
-- **Phase 5 — Automation** 🔜 Cron scenes, sunset-aware, CI/CD indicator, voice input
+- **Phase 4 — Telegram & WhatsApp** ✅ Bot listeners, message routing, unified start
+- **Phase 5 — Automation** 🔜 Cron scenes, sunset-aware, CI/CD indicator
 
 ---
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,14 +1,15 @@
 {
-  "name": "luminaa",
+  "name": "lumina",
   "version": "0.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "luminaa",
+      "name": "lumina",
       "version": "0.1.0",
       "dependencies": {
         "@hapi/boom": "^10.0.1",
+        "@inquirer/prompts": "^8.4.1",
         "@whiskeysockets/baileys": "^7.0.0-rc.9",
         "commander": "^14.0.3",
         "dotenv": "^17.3.1",
@@ -1092,6 +1093,346 @@
       },
       "funding": {
         "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@inquirer/ansi": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/@inquirer/ansi/-/ansi-2.0.5.tgz",
+      "integrity": "sha512-doc2sWgJpbFQ64UflSVd17ibMGDuxO1yKgOgLMwavzESnXjFWJqUeG8saYosqKpHp4kWiM5x1nXvEjbpx90gzw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=23.5.0 || ^22.13.0 || ^21.7.0 || ^20.12.0"
+      }
+    },
+    "node_modules/@inquirer/checkbox": {
+      "version": "5.1.3",
+      "resolved": "https://registry.npmjs.org/@inquirer/checkbox/-/checkbox-5.1.3.tgz",
+      "integrity": "sha512-+G7I8CT+EHv/hasNfUl3P37DVoMoZfpA+2FXmM54dA8MxYle1YqucxbacxHalw1iAFSdKNEDTGNV7F+j1Ldqcg==",
+      "license": "MIT",
+      "dependencies": {
+        "@inquirer/ansi": "^2.0.5",
+        "@inquirer/core": "^11.1.8",
+        "@inquirer/figures": "^2.0.5",
+        "@inquirer/type": "^4.0.5"
+      },
+      "engines": {
+        "node": ">=23.5.0 || ^22.13.0 || ^21.7.0 || ^20.12.0"
+      },
+      "peerDependencies": {
+        "@types/node": ">=18"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@inquirer/confirm": {
+      "version": "6.0.11",
+      "resolved": "https://registry.npmjs.org/@inquirer/confirm/-/confirm-6.0.11.tgz",
+      "integrity": "sha512-pTpHjg0iEIRMYV/7oCZUMf27/383E6Wyhfc/MY+AVQGEoUobffIYWOK9YLP2XFRGz/9i6WlTQh1CkFVIo2Y7XA==",
+      "license": "MIT",
+      "dependencies": {
+        "@inquirer/core": "^11.1.8",
+        "@inquirer/type": "^4.0.5"
+      },
+      "engines": {
+        "node": ">=23.5.0 || ^22.13.0 || ^21.7.0 || ^20.12.0"
+      },
+      "peerDependencies": {
+        "@types/node": ">=18"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@inquirer/core": {
+      "version": "11.1.8",
+      "resolved": "https://registry.npmjs.org/@inquirer/core/-/core-11.1.8.tgz",
+      "integrity": "sha512-/u+yJk2pOKNDOh1ZgdUH2RQaRx6OOH4I0uwL95qPvTFTIL38YBsuSC4r1yXBB3Q6JvNqFFc202gk0Ew79rrcjA==",
+      "license": "MIT",
+      "dependencies": {
+        "@inquirer/ansi": "^2.0.5",
+        "@inquirer/figures": "^2.0.5",
+        "@inquirer/type": "^4.0.5",
+        "cli-width": "^4.1.0",
+        "fast-wrap-ansi": "^0.2.0",
+        "mute-stream": "^3.0.0",
+        "signal-exit": "^4.1.0"
+      },
+      "engines": {
+        "node": ">=23.5.0 || ^22.13.0 || ^21.7.0 || ^20.12.0"
+      },
+      "peerDependencies": {
+        "@types/node": ">=18"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@inquirer/core/node_modules/signal-exit": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
+      "integrity": "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/@inquirer/editor": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/@inquirer/editor/-/editor-5.1.0.tgz",
+      "integrity": "sha512-6wlkYl65Qfayy48gPCfU4D7li6KCAGN79mLXa/tYHZH99OfZ820yY+HA+DgE88r8YwwgeuY6PQgNqMeK6LuMmw==",
+      "license": "MIT",
+      "dependencies": {
+        "@inquirer/core": "^11.1.8",
+        "@inquirer/external-editor": "^3.0.0",
+        "@inquirer/type": "^4.0.5"
+      },
+      "engines": {
+        "node": ">=23.5.0 || ^22.13.0 || ^21.7.0 || ^20.12.0"
+      },
+      "peerDependencies": {
+        "@types/node": ">=18"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@inquirer/expand": {
+      "version": "5.0.12",
+      "resolved": "https://registry.npmjs.org/@inquirer/expand/-/expand-5.0.12.tgz",
+      "integrity": "sha512-vOfrB33b7YIZfDauXS8vNNz2Z86FozTZLIt7e+7/dCaPJ1RXZsHCuI9TlcERzEUq57vkM+UdnBgxP0rFd23JYQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@inquirer/core": "^11.1.8",
+        "@inquirer/type": "^4.0.5"
+      },
+      "engines": {
+        "node": ">=23.5.0 || ^22.13.0 || ^21.7.0 || ^20.12.0"
+      },
+      "peerDependencies": {
+        "@types/node": ">=18"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@inquirer/external-editor": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@inquirer/external-editor/-/external-editor-3.0.0.tgz",
+      "integrity": "sha512-lDSwMgg+M5rq6JKBYaJwSX6T9e/HK2qqZ1oxmOwn4AQoJE5D+7TumsxLGC02PWS//rkIVqbZv3XA3ejsc9FYvg==",
+      "license": "MIT",
+      "dependencies": {
+        "chardet": "^2.1.1",
+        "iconv-lite": "^0.7.2"
+      },
+      "engines": {
+        "node": ">=23.5.0 || ^22.13.0 || ^21.7.0 || ^20.12.0"
+      },
+      "peerDependencies": {
+        "@types/node": ">=18"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@inquirer/figures": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/@inquirer/figures/-/figures-2.0.5.tgz",
+      "integrity": "sha512-NsSs4kzfm12lNetHwAn3GEuH317IzpwrMCbOuMIVytpjnJ90YYHNwdRgYGuKmVxwuIqSgqk3M5qqQt1cDk0tGQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=23.5.0 || ^22.13.0 || ^21.7.0 || ^20.12.0"
+      }
+    },
+    "node_modules/@inquirer/input": {
+      "version": "5.0.11",
+      "resolved": "https://registry.npmjs.org/@inquirer/input/-/input-5.0.11.tgz",
+      "integrity": "sha512-twUWidn4ocPO8qi6fRM7tNWt7W1FOnOZqQ+/+PsfLUacMR5rFLDPK9ql0nBPwxi0oELbo8T5NhRs8B2+qQEqFQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@inquirer/core": "^11.1.8",
+        "@inquirer/type": "^4.0.5"
+      },
+      "engines": {
+        "node": ">=23.5.0 || ^22.13.0 || ^21.7.0 || ^20.12.0"
+      },
+      "peerDependencies": {
+        "@types/node": ">=18"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@inquirer/number": {
+      "version": "4.0.11",
+      "resolved": "https://registry.npmjs.org/@inquirer/number/-/number-4.0.11.tgz",
+      "integrity": "sha512-Vscmim9TCksQsfjPtka/JwPUcbLhqWYrgfPf1cHrCm24X/F2joFwnageD50yMKsaX14oNGOyKf/RNXAFkNjWpA==",
+      "license": "MIT",
+      "dependencies": {
+        "@inquirer/core": "^11.1.8",
+        "@inquirer/type": "^4.0.5"
+      },
+      "engines": {
+        "node": ">=23.5.0 || ^22.13.0 || ^21.7.0 || ^20.12.0"
+      },
+      "peerDependencies": {
+        "@types/node": ">=18"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@inquirer/password": {
+      "version": "5.0.11",
+      "resolved": "https://registry.npmjs.org/@inquirer/password/-/password-5.0.11.tgz",
+      "integrity": "sha512-9KZFeRaNHIcejtPb0wN4ddFc7EvobVoAFa049eS3LrDZFxI8O7xUXiITEOinBzkZFAIwY5V4yzQae/QfO9cbbg==",
+      "license": "MIT",
+      "dependencies": {
+        "@inquirer/ansi": "^2.0.5",
+        "@inquirer/core": "^11.1.8",
+        "@inquirer/type": "^4.0.5"
+      },
+      "engines": {
+        "node": ">=23.5.0 || ^22.13.0 || ^21.7.0 || ^20.12.0"
+      },
+      "peerDependencies": {
+        "@types/node": ">=18"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@inquirer/prompts": {
+      "version": "8.4.1",
+      "resolved": "https://registry.npmjs.org/@inquirer/prompts/-/prompts-8.4.1.tgz",
+      "integrity": "sha512-AH5xPQ997K7e0F0vulPlteIHke2awMkFi8F0dBemrDfmvtPmHJo82mdHbONC4F/t8d1NHwrbI5cGVI+RbLWdoQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@inquirer/checkbox": "^5.1.3",
+        "@inquirer/confirm": "^6.0.11",
+        "@inquirer/editor": "^5.1.0",
+        "@inquirer/expand": "^5.0.12",
+        "@inquirer/input": "^5.0.11",
+        "@inquirer/number": "^4.0.11",
+        "@inquirer/password": "^5.0.11",
+        "@inquirer/rawlist": "^5.2.7",
+        "@inquirer/search": "^4.1.7",
+        "@inquirer/select": "^5.1.3"
+      },
+      "engines": {
+        "node": ">=23.5.0 || ^22.13.0 || ^21.7.0 || ^20.12.0"
+      },
+      "peerDependencies": {
+        "@types/node": ">=18"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@inquirer/rawlist": {
+      "version": "5.2.7",
+      "resolved": "https://registry.npmjs.org/@inquirer/rawlist/-/rawlist-5.2.7.tgz",
+      "integrity": "sha512-AqRMiD9+uE1lskDPrdqHwrV/EUmxKEBLX44SR7uxK3vD2413AmVfE5EQaPeNzYf5Pq5SitHJDYUFVF0poIr09w==",
+      "license": "MIT",
+      "dependencies": {
+        "@inquirer/core": "^11.1.8",
+        "@inquirer/type": "^4.0.5"
+      },
+      "engines": {
+        "node": ">=23.5.0 || ^22.13.0 || ^21.7.0 || ^20.12.0"
+      },
+      "peerDependencies": {
+        "@types/node": ">=18"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@inquirer/search": {
+      "version": "4.1.7",
+      "resolved": "https://registry.npmjs.org/@inquirer/search/-/search-4.1.7.tgz",
+      "integrity": "sha512-1y7+0N65AWk5RdlXH/Kn13txf3IjIQ7OEfhCEkDTU+h5wKMLq8DUF3P6z+/kLSxDGDtQT1dRBWEUC3o/VvImsQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@inquirer/core": "^11.1.8",
+        "@inquirer/figures": "^2.0.5",
+        "@inquirer/type": "^4.0.5"
+      },
+      "engines": {
+        "node": ">=23.5.0 || ^22.13.0 || ^21.7.0 || ^20.12.0"
+      },
+      "peerDependencies": {
+        "@types/node": ">=18"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@inquirer/select": {
+      "version": "5.1.3",
+      "resolved": "https://registry.npmjs.org/@inquirer/select/-/select-5.1.3.tgz",
+      "integrity": "sha512-zYyqWgGQi3NhBcNq4Isc5rB3oEdQEh1Q/EcAnOW0FK4MpnXWkvSBYgA4cYrTM4A9UB573omouZbnL9JJ74Mq3A==",
+      "license": "MIT",
+      "dependencies": {
+        "@inquirer/ansi": "^2.0.5",
+        "@inquirer/core": "^11.1.8",
+        "@inquirer/figures": "^2.0.5",
+        "@inquirer/type": "^4.0.5"
+      },
+      "engines": {
+        "node": ">=23.5.0 || ^22.13.0 || ^21.7.0 || ^20.12.0"
+      },
+      "peerDependencies": {
+        "@types/node": ">=18"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@inquirer/type": {
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/@inquirer/type/-/type-4.0.5.tgz",
+      "integrity": "sha512-aetVUNeKNc/VriqXlw1NRSW0zhMBB0W4bNbWRJgzRl/3d0QNDQFfk0GO5SDdtjMZVg6o8ZKEiadd7SCCzoOn5Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=23.5.0 || ^22.13.0 || ^21.7.0 || ^20.12.0"
+      },
+      "peerDependencies": {
+        "@types/node": ">=18"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        }
       }
     },
     "node_modules/@jridgewell/gen-mapping": {
@@ -3070,6 +3411,12 @@
         "url": "https://github.com/chalk/chalk?sponsor=1"
       }
     },
+    "node_modules/chardet": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/chardet/-/chardet-2.1.1.tgz",
+      "integrity": "sha512-PsezH1rqdV9VvyNhxxOW32/d75r01NY7TQCmOqomRo15ZSOKbpTFVsfjghxo6JloQUCGnH4k1LGu0R4yCLlWQQ==",
+      "license": "MIT"
+    },
     "node_modules/cli-cursor": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-3.1.0.tgz",
@@ -3092,6 +3439,15 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/cli-width": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/cli-width/-/cli-width-4.1.0.tgz",
+      "integrity": "sha512-ouuZd4/dm2Sw5Gmqy6bGyNNNe1qt9RpmxveLSO7KcgsTnU7RXfsw+/bukWGo1abgBiMAic068rclZsO4IWmmxQ==",
+      "license": "ISC",
+      "engines": {
+        "node": ">= 12"
       }
     },
     "node_modules/client-only": {
@@ -4096,6 +4452,30 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/fast-string-truncated-width": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/fast-string-truncated-width/-/fast-string-truncated-width-3.0.3.tgz",
+      "integrity": "sha512-0jjjIEL6+0jag3l2XWWizO64/aZVtpiGE3t0Zgqxv0DPuxiMjvB3M24fCyhZUO4KomJQPj3LTSUnDP3GpdwC0g==",
+      "license": "MIT"
+    },
+    "node_modules/fast-string-width": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/fast-string-width/-/fast-string-width-3.0.2.tgz",
+      "integrity": "sha512-gX8LrtNEI5hq8DVUfRQMbr5lpaS4nMIWV+7XEbXk2b8kiQIizgnlr12B4dA3ZEx3308ze0O4Q1R+cHts8kyUJg==",
+      "license": "MIT",
+      "dependencies": {
+        "fast-string-truncated-width": "^3.0.2"
+      }
+    },
+    "node_modules/fast-wrap-ansi": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/fast-wrap-ansi/-/fast-wrap-ansi-0.2.0.tgz",
+      "integrity": "sha512-rLV8JHxTyhVmFYhBJuMujcrHqOT2cnO5Zxj37qROj23CP39GXubJRBUFF0z8KFK77Uc0SukZUf7JZhsVEQ6n8w==",
+      "license": "MIT",
+      "dependencies": {
+        "fast-string-width": "^3.0.2"
+      }
+    },
     "node_modules/fastq": {
       "version": "1.20.1",
       "resolved": "https://registry.npmjs.org/fastq/-/fastq-1.20.1.tgz",
@@ -4525,6 +4905,22 @@
       "resolved": "https://registry.npmjs.org/hookified/-/hookified-1.15.1.tgz",
       "integrity": "sha512-MvG/clsADq1GPM2KGo2nyfaWVyn9naPiXrqIe4jYjXNZQt238kWyOGrsyc/DmRAQ+Re6yeo6yX/yoNCG5KAEVg==",
       "license": "MIT"
+    },
+    "node_modules/iconv-lite": {
+      "version": "0.7.2",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.7.2.tgz",
+      "integrity": "sha512-im9DjEDQ55s9fL4EYzOAv0yMqmMBSZp6G0VvFyTMPKWxiSBHUj9NW/qqLmXUwXrrM7AvqSlTCfvqRb0cM8yYqw==",
+      "license": "MIT",
+      "dependencies": {
+        "safer-buffer": ">= 2.1.2 < 3.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
     },
     "node_modules/ieee754": {
       "version": "1.2.1",
@@ -5726,6 +6122,15 @@
         "node": ">=18"
       }
     },
+    "node_modules/mute-stream": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-3.0.0.tgz",
+      "integrity": "sha512-dkEJPVvun4FryqBmZ5KhDo0K9iDXAwn08tMLDinNdRBNPcYEDiWYysLcc6k3mjTMlbP9KyylvRpd4wFtwrT9rw==",
+      "license": "ISC",
+      "engines": {
+        "node": "^20.17.0 || >=22.9.0"
+      }
+    },
     "node_modules/nanoid": {
       "version": "3.3.11",
       "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.11.tgz",
@@ -6725,6 +7130,12 @@
       "engines": {
         "node": ">=10"
       }
+    },
+    "node_modules/safer-buffer": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
+      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
+      "license": "MIT"
     },
     "node_modules/sandwich-stream": {
       "version": "2.0.2",

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "luminaa",
+  "name": "lumina",
   "version": "0.1.0",
   "private": true,
   "bin": {

--- a/package.json
+++ b/package.json
@@ -12,7 +12,10 @@
     "lint": "eslint",
     "cli": "npx tsx src/cli/index.ts",
     "whatsapp": "npx tsx src/integrations/whatsapp/index.ts",
-    "telegram": "npx tsx src/integrations/telegram/index.ts"
+    "telegram": "npx tsx src/integrations/telegram/index.ts",
+    "websocket": "npx tsx src/integrations/websocket/index.ts",
+    "cron": "npx tsx src/service/runner.ts",
+    "start:all": "npx concurrently -c \"bgBlue.bold,bgMagenta.bold,bgCyan.bold,bgGreen.bold\" \"npm run whatsapp\" \"npm run telegram\" \"npm run websocket\" \"npm run cron\""
   },
   "dependencies": {
     "@hapi/boom": "^10.0.1",

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
   },
   "dependencies": {
     "@hapi/boom": "^10.0.1",
+    "@inquirer/prompts": "^8.4.1",
     "@whiskeysockets/baileys": "^7.0.0-rc.9",
     "commander": "^14.0.3",
     "dotenv": "^17.3.1",

--- a/setup.sh
+++ b/setup.sh
@@ -46,10 +46,18 @@ echo -e "${GREEN}Python requirements installed in .venv.${NC}"
 echo -e "${BLUE}4/6 Registering lumina-cli...${NC}"
 chmod +x src/cli/index.ts
 
-# 5. Setup .env.local file
-echo "TUYA_ACCESS_ID=" >> .env.local
-echo "TUYA_ACCESS_SECRET=" >> .env.local
-echo -e "${GREEN}.env.local created${NC}"
+echo -e "${BLUE}5/6 Setting up .env.local file...${NC}"
+if [ ! -f .env.local ]; then
+    echo "TUYA_ACCESS_ID=" > .env.local
+    echo "TUYA_ACCESS_SECRET=" >> .env.local
+    echo "TELEGRAM_BOT_TOKEN=" >> .env.local
+    echo "TELEGRAM_ALLOWED_USER_ID=" >> .env.local
+    echo "WHATSAPP_ALLOWED_JIDS=" >> .env.local
+    echo "WEBSOCKET_PORT=8080" >> .env.local
+    echo -e "${GREEN}.env.local created. Please populate it with your tokens.${NC}"
+else
+    echo -e "${YELLOW}.env.local already exists, skipping creation.${NC}"
+fi
 
 # 6. Final Steps
 echo -e "${YELLOW}Final Step: Global Access${NC}"
@@ -61,4 +69,5 @@ echo -e "${GREEN}SUCCESS! Lumina setup is complete.${NC}"
 echo -e "You can now run commands using:"
 echo -e "1. ${BLUE}./src/cli/index.ts bulb on${NC}"
 echo -e "2. ${BLUE}npm run cli -- bulb on${NC}"
-echo -e "3. ${BLUE}lumina-cli bulb on${NC} (after linking)"
+echo -e "3. ${BLUE}npm run start:all${NC} (Runs Telegram, WhatsApp, WebSocket & Cron)"
+echo -e "4. ${BLUE}lumina-cli bulb on${NC} (after linking)"

--- a/src/agent.ts
+++ b/src/agent.ts
@@ -104,14 +104,19 @@ export class AgentLoop {
       
       this.messages.push(msg);
 
+      // If there are tool calls, execute them all in parallel and collect results
       if (msg.tool_calls && msg.tool_calls.length > 0) {
-        for (const tool of msg.tool_calls) {
-          const toolResult = await executeTool(tool);
+        const toolResults = await Promise.all(
+          msg.tool_calls.map(tool => executeTool(tool))
+        );
+
+        for (const result of toolResults) {
           this.messages.push({
             role: 'tool',
-            content: JSON.stringify(toolResult)
+            content: JSON.stringify(result)
           });
         }
+
         return await this.runLoop();
       }
 

--- a/src/agent.ts
+++ b/src/agent.ts
@@ -4,9 +4,22 @@ import { executeTool } from './model/tools/executor';
 
 import ora from 'ora';
 
-const DEFAULT_SYSTEM_PROMPT = `
+function buildSystemPrompt(): string {
+  const now = new Date();
+  const timezone = Intl.DateTimeFormat().resolvedOptions().timeZone;
+  const dateStr = now.toLocaleDateString('en-US', { weekday: 'long', year: 'numeric', month: 'long', day: 'numeric', timeZone: timezone });
+  const timeStr = now.toLocaleTimeString('en-US', { hour: '2-digit', minute: '2-digit', timeZone: timezone });
+
+  return `
 You are Lumina, an intelligent assistant that controls smart home devices.
 Use the provided tools to interact with physical hardware.
+
+Current context:
+- Date: ${dateStr}
+- Time: ${timeStr}
+- Timezone: ${timezone}
+
+Use this context to interpret time-based commands intelligently. For example, "set evening mood" should consider the actual current time.
 
 If the user asks you to do something with their lights, immediately use the 'run_bulb_command' tool.
 Do not ask for permission, just execute the tool.
@@ -18,7 +31,8 @@ You can also manage scheduled automations:
 - To LIST/VIEW all automations: use 'list_automations'. Present results in a readable format showing ID, name, schedule, and status. Always include the ID so the user can reference it for removal.
 - To REMOVE/DELETE an automation: use 'remove_automation'. You can match by ID or name. If the user refers to an automation by name, first call list_automations to find the exact ID, then remove it.
 After any automation action, confirm what happened.
-`;
+`.trim();
+}
 
 export class AgentLoop {
   private messages: OllamaMessage[] = [];
@@ -26,11 +40,13 @@ export class AgentLoop {
   constructor() {
     this.messages.push({
       role: 'system',
-      content: DEFAULT_SYSTEM_PROMPT.trim()
+      content: buildSystemPrompt()
     });
   }
 
   public async processUserInput(input: string): Promise<string> {
+    // Refresh the system prompt with the current time on each new user message
+    this.messages[0] = { role: 'system', content: buildSystemPrompt() };
     this.messages.push({ role: 'user', content: input });
     return await this.runLoop();
   }
@@ -74,11 +90,9 @@ export class AgentLoop {
       if (isTyping) {
         console.log(); // Complete the printed line
       } else if (spinner.isSpinning) {
-        // In case it finished without printing text (just tool calls)
         spinner.stop();
       }
 
-      // Reconstruct the message
       const msg: OllamaMessage & { tool_calls?: ToolCall[] } = {
         role: 'assistant',
         content: fullContent
@@ -90,7 +104,6 @@ export class AgentLoop {
       
       this.messages.push(msg);
 
-      // If there are tool calls, execute them and recurse
       if (msg.tool_calls && msg.tool_calls.length > 0) {
         for (const tool of msg.tool_calls) {
           const toolResult = await executeTool(tool);
@@ -99,10 +112,9 @@ export class AgentLoop {
             content: JSON.stringify(toolResult)
           });
         }
-        return await this.runLoop(); // Recurse to get the final textual response
+        return await this.runLoop();
       }
 
-      // Return the final text content
       return fullContent || 'Action completed.';
     } catch (e: any) {
       const message = e instanceof Error ? e.message : String(e);

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -21,14 +21,17 @@ const program = new Command();
 program
   .name("lumina-cli")
   .description("CLI to control smart bulbs and other devices")
-  .option(
-    "-m, --message <text>",
-    "natural language message to control the device",
-  )
+  .argument('[arg1]', 'Primary command (action or type)')
+  .argument('[arg2]', 'Target name or action')
+  .argument('[arg3]', 'Target action if resolving by specific name')
+  .argument('[arg4]', 'Optional value for action')
+  .option("-m, --message <text>", "natural language message to control the device")
   .option("-d, --device <name>", "specific device ID or name")
   .option("-s, --scan", "scan for devices")
+  .option("-a, --all", "apply to all devices bypass prompt")
+  .option("-j, --json", "Output results as JSON")
   .version("0.1.0")
-  .action(async (options) => {
+  .action(async (arg1, arg2, arg3, arg4, options) => {
     if (options.scan) {
       await scanDevices();
       return;
@@ -37,51 +40,80 @@ program
     if (options.message) {
       const target = options.device ? ` for device: ${options.device}` : "";
       console.log(`> Processing message: "${options.message}"${target}\n`);
-
       const response = await handleMessage(options.message);
       console.log(`\n> Lumina: ${response}`);
-    } else {
-      program.help();
+      return;
     }
-  });
 
-program
-  .command("bulb")
-  .description("Control smart bulbs")
-  .argument(
-    "[action]",
-    "Action to perform (on, off, toggle, status, brightness, color)",
-  )
-  .argument("[value]", "Value for brightness (1-100) or color (hex)")
-  .option("-d, --device <name>", "Specific device ID or Name")
-  .option("-j, --json", "Output results as JSON")
-  .option(
-    "-m, --message <text>",
-    "Natural language message to control the bulb",
-  )
-  .action(async (action, value, options) => {
+    if (!arg1) {
+      program.help();
+      return;
+    }
+
+    const { resolveGlobalConflict } = await import('./prompt');
+    const { registry } = await import('../service/registry');
+
+    const validActions = ['on', 'off', 'toggle', 'status', 'brightness', 'color'];
+    let targetDevices: any[] = [];
+    let actionToRun = '';
+    let actionValue = '';
+
     try {
-      if (options.message) {
-        console.log(`Processing message: "${options.message}"\n`);
-        const response = await handleMessage(options.message);
-        console.log(`\n> Lumina: ${response}`);
-        return;
+      if (validActions.includes(arg1)) {
+        actionToRun = arg1;
+        actionValue = arg2 || '';
+        
+        if (options.all) {
+          targetDevices = registry.getAllDevices();
+        } else {
+          const resolution = await resolveGlobalConflict(arg1);
+          if (!resolution) process.exit(0);
+
+          if (resolution.type === 'all') {
+            targetDevices = registry.getAllDevices();
+          } else if (resolution.type === 'category') {
+            targetDevices = registry.getDevicesByType(resolution.category);
+          } else if (resolution.type === 'device') {
+            const dev = registry.getDeviceByIdOrName(resolution.deviceId);
+            if (dev) targetDevices = [dev];
+          }
+        }
+      } else {
+        if (arg2 && validActions.includes(arg2)) {
+          // lumina bulb off
+          actionToRun = arg2;
+          actionValue = arg3 || '';
+          targetDevices = registry.getDevicesByType(arg1);
+        } else if (arg2 && arg3 && validActions.includes(arg3)) {
+          // lumina bulb "Living Room" off
+          actionToRun = arg3;
+          actionValue = arg4 || '';
+          const dev = registry.getDeviceByIdOrName(arg2);
+          if (dev) targetDevices = [dev];
+        } else {
+          console.error(`Invalid command format. Action must be one of: ${validActions.join(', ')}`);
+          process.exit(1);
+        }
       }
 
-      if (!action) {
-        console.error("error: missing required argument 'action'");
+      if (targetDevices.length === 0) {
+        console.error('No matching devices found to apply the command.');
         process.exit(1);
       }
 
-      const result = await runBulbCommand(action, value, options);
-      if (options.json) {
-        console.log(JSON.stringify(result, null, 2));
-      } else {
-        console.log(result);
+      // In Step 4 we will enable concurrent Promise.all execution, for now we run sequentially
+      for (const dev of targetDevices) {
+        console.log(`Sending '${actionToRun}' to ${dev.name}...`);
+        const result = await runBulbCommand(actionToRun, actionValue, { ...options, device: dev.id });
+        if (options.json) {
+          console.log(JSON.stringify(result, null, 2));
+        } else {
+           console.log(result);
+        }
       }
-    } catch (error) {
-      const message = error instanceof Error ? error.message : String(error);
-      console.error(message);
+
+    } catch (error: any) {
+      console.error(error.message || String(error));
       process.exit(1);
     }
   });

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -106,14 +106,16 @@ program
       const { executeCommandOnMultiple } = await import('../util/tinytuya');
       const results = await executeCommandOnMultiple(targetDevices, actionToRun, actionValue, options);
       
-      results.forEach(({ device, success, result, error }) => {
-        if (success) {
+      results.forEach((res) => {
+        if (res.success) {
+          const { device, result } = res as { device: any, result: any, success: true };
           if (options.json) {
             console.log(JSON.stringify({ device: device.name, result }, null, 2));
           } else {
             console.log(`✅ [${device.name}]: Actions pushed successfully.`);
           }
         } else {
+          const { device, error } = res as { device: any, error: any, success: false };
           console.error(`❌ [${device.name}] Error:`, error?.message || String(error));
         }
       });

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -101,16 +101,22 @@ program
         process.exit(1);
       }
 
-      // In Step 4 we will enable concurrent Promise.all execution, for now we run sequentially
-      for (const dev of targetDevices) {
-        console.log(`Sending '${actionToRun}' to ${dev.name}...`);
-        const result = await runBulbCommand(actionToRun, actionValue, { ...options, device: dev.id });
-        if (options.json) {
-          console.log(JSON.stringify(result, null, 2));
+      // Execute requested actions in parallel
+      console.log(`Sending '${actionToRun}' to ${targetDevices.length} device(s) concurrently...`);
+      const { executeCommandOnMultiple } = await import('../util/tinytuya');
+      const results = await executeCommandOnMultiple(targetDevices, actionToRun, actionValue, options);
+      
+      results.forEach(({ device, success, result, error }) => {
+        if (success) {
+          if (options.json) {
+            console.log(JSON.stringify({ device: device.name, result }, null, 2));
+          } else {
+            console.log(`✅ [${device.name}]: Actions pushed successfully.`);
+          }
         } else {
-           console.log(result);
+          console.error(`❌ [${device.name}] Error:`, error?.message || String(error));
         }
-      }
+      });
 
     } catch (error: any) {
       console.error(error.message || String(error));

--- a/src/cli/prompt.ts
+++ b/src/cli/prompt.ts
@@ -1,0 +1,75 @@
+import { select, confirm } from '@inquirer/prompts';
+import { registry, TuyaDevice } from '../service/registry';
+
+/**
+ * When a global action is invoked but the target is ambiguous,
+ * prompt the user to clarify.
+ */
+export async function resolveGlobalConflict(action: string): Promise<{ type: 'all' } | { type: 'category'; category: string } | { type: 'device'; deviceId: string } | null> {
+  const answer = await select({
+    message: `You issued a global '${action}'. Which devices should this apply to?`,
+    choices: [
+      { name: `All Devices`, value: 'all' },
+      { name: `All Bulbs`, value: 'bulb' },
+      { name: `All Fans`, value: 'fan' },
+      { name: `All Plugs`, value: 'plug' },
+      { name: `Select a Specific Device...`, value: 'specific' },
+      { name: `Cancel`, value: 'cancel' }
+    ],
+  });
+
+  if (answer === 'cancel') {
+    console.log('Action cancelled.');
+    return null;
+  }
+
+  if (answer === 'all') {
+    const isSure = await confirm({ message: `Are you sure you want to apply '${action}' to EVERY device?` });
+    if (!isSure) return null;
+    return { type: 'all' };
+  }
+
+  if (answer === 'bulb' || answer === 'fan' || answer === 'plug') {
+    return { type: 'category', category: answer };
+  }
+
+  if (answer === 'specific') {
+    const devices = registry.getAllDevices();
+    const deviceId = await promptDeviceSelection(devices, `Which device do you want to turn ${action}?`);
+    if (!deviceId) return null;
+    return { type: 'device', deviceId };
+  }
+
+  return null;
+}
+
+/**
+ * Prompts the user to select a device from a provided list.
+ */
+export async function promptDeviceSelection(devices: TuyaDevice[], message = 'Select a device:'): Promise<string | null> {
+  if (devices.length === 0) {
+    console.log('No devices available to select.');
+    return null;
+  }
+
+  const choices = devices.map(device => ({
+    name: `${device.name} [${device.ip || 'Unknown IP'}]`,
+    value: device.id,
+    description: `Category: ${device.category} | Product: ${device.product_name}`
+  }));
+
+  choices.push({ name: 'Cancel', value: 'cancel', description: '' });
+
+  const answer = await select({
+    message,
+    choices,
+    pageSize: 10,
+  });
+
+  if (answer === 'cancel') {
+    console.log('Action cancelled.');
+    return null;
+  }
+
+  return answer;
+}

--- a/src/integrations/router.ts
+++ b/src/integrations/router.ts
@@ -2,20 +2,32 @@ import { AgentLoop } from '../agent';
 
 /**
  * Message Router
- * Routes messages from CLI, Telegram, or WhatsApp to the AI Agent.
+ * Routes messages from CLI, Telegram, WhatsApp, etc. to the AI Agent.
+ * Each user gets their own isolated AgentLoop so conversation history
+ * is never shared across users.
  */
 
-// Simple shared agent instance for now.
-// In the future, we can use a Map<string, AgentLoop> to track users.
-const agent = new AgentLoop();
+const agents = new Map<string, AgentLoop>();
 
 /**
- * Handles an incoming message and returns the assistant's response.
- * @param input The text message from the user
+ * Returns the AgentLoop for a given user, creating one if it doesn't exist.
+ */
+function getAgentForUser(userId: string): AgentLoop {
+  if (!agents.has(userId)) {
+    agents.set(userId, new AgentLoop());
+  }
+  return agents.get(userId)!;
+}
+
+/**
+ * Handles an incoming message for a specific user and returns the assistant's response.
+ * @param input   The text message from the user
+ * @param userId  A unique identifier for the user (Telegram ID, WhatsApp JID, 'cli', etc.)
  * @returns The assistant's textual response
  */
-export async function handleMessage(input: string): Promise<string> {
+export async function handleMessage(input: string, userId: string = 'cli'): Promise<string> {
   try {
+    const agent = getAgentForUser(userId);
     const response = await agent.processUserInput(input);
     return response;
   } catch (error) {

--- a/src/integrations/telegram/index.ts
+++ b/src/integrations/telegram/index.ts
@@ -73,3 +73,11 @@ export async function startTelegramBot() {
 
   console.log('Bot is running in long-polling mode...');
 }
+
+// Entry point — invoked when run directly
+if (require.main === module || process.argv[1]?.endsWith('telegram/index.ts')) {
+  startTelegramBot().catch((err) => {
+    console.error('[Telegram] Fatal startup error:', err);
+    process.exit(1);
+  });
+}

--- a/src/integrations/websocket/index.ts
+++ b/src/integrations/websocket/index.ts
@@ -93,3 +93,11 @@ export async function startWebSocketServer() {
     wss.close();
   });
 }
+
+// Entry point — invoked when run directly
+if (require.main === module || process.argv[1]?.endsWith('websocket/index.ts')) {
+  startWebSocketServer().catch((err) => {
+    console.error('[WebSocket] Fatal startup error:', err);
+    process.exit(1);
+  });
+}

--- a/src/service/registry.ts
+++ b/src/service/registry.ts
@@ -1,0 +1,93 @@
+import { join } from 'path';
+import { readFileSync, existsSync } from 'fs';
+import { CONFIG_DIR } from '../util/paths';
+
+export interface TuyaDevice {
+  name: string;
+  id: string;
+  key: string;
+  mac: string;
+  uuid: string;
+  sn?: string;
+  category: string;
+  product_name: string;
+  product_id: string;
+  biz_type: number;
+  model: string;
+  sub: boolean;
+  ip: string;
+  version: string;
+  // Let mapping be an arbitrary object for now to avoid bloated typings
+  mapping?: Record<string, any>;
+}
+
+export class DeviceRegistry {
+  private devices: TuyaDevice[] = [];
+  private static instance: DeviceRegistry;
+
+  private constructor() {
+    this.loadDevices();
+  }
+
+  public static getInstance(): DeviceRegistry {
+    if (!DeviceRegistry.instance) {
+      DeviceRegistry.instance = new DeviceRegistry();
+    }
+    return DeviceRegistry.instance;
+  }
+
+  private loadDevices() {
+    const devicesPath = join(CONFIG_DIR, 'devices.json');
+    if (!existsSync(devicesPath)) {
+      console.warn('⚠️ devices.json not found in config directory. You may need to run scan first.');
+      return;
+    }
+
+    try {
+      const data = readFileSync(devicesPath, 'utf8');
+      this.devices = JSON.parse(data);
+    } catch (error) {
+      console.error('❌ Failed to parse devices.json:', error);
+    }
+  }
+
+  public getAllDevices(): TuyaDevice[] {
+    return this.devices;
+  }
+
+  public getDeviceByIdOrName(identifier: string): TuyaDevice | undefined {
+    // Exact match for id first
+    let device = this.devices.find((d) => d.id === identifier);
+    if (device) return device;
+
+    // Direct match for name (case-insensitive)
+    const lowerId = identifier.toLowerCase();
+    device = this.devices.find((d) => d.name.toLowerCase() === lowerId);
+    if (device) return device;
+
+    // Partial match for name
+    device = this.devices.find((d) => d.name.toLowerCase().includes(lowerId));
+    return device;
+  }
+
+  public getDevicesByType(type: string): TuyaDevice[] {
+    const lowerType = type.toLowerCase();
+    // A rudimentary check based on name/category to group devices if you specify e.g. "bulb"
+    return this.devices.filter((d) => {
+      // Common Tuya Categories: 
+      // dj = smart bulb, cz = smart plug, fs = fan
+      // We can also just search the product_name for keywords
+      const matchesCategory = 
+        (lowerType === 'bulb' && d.category === 'dj') ||
+        (lowerType === 'plug' && d.category === 'cz') ||
+        (lowerType === 'fan' && d.category === 'fs');
+
+      const matchesName = d.product_name.toLowerCase().includes(lowerType) || d.name.toLowerCase().includes(lowerType);
+      
+      return matchesCategory || matchesName;
+    });
+  }
+}
+
+// Export a singleton instance by default for easy usage
+export const registry = DeviceRegistry.getInstance();

--- a/src/service/runner.ts
+++ b/src/service/runner.ts
@@ -12,8 +12,9 @@ async function main() {
       console.error(`❌ Reload Error: ${message}`);
     });
   });
+  // Keep the process alive even if there are no cron tasks yet
+  setInterval(() => {}, 1000 * 60 * 60);
 
-  // Keep the process alive
   // node-cron tasks will keep the event loop alive, but we can also handle graceful shutdown
   process.on('SIGINT', () => {
     console.log('\n🛑 Stopping Cron Service...');

--- a/src/util/tinytuya.ts
+++ b/src/util/tinytuya.ts
@@ -61,3 +61,18 @@ export async function scanDevices() {
     process.exit(1);
   }
 }
+
+export async function executeCommandOnMultiple(
+  devices: any[],
+  command: string,
+  value?: string,
+  options: { json?: boolean } = {}
+) {
+  const promises = devices.map(device => {
+    return runBulbCommand(command, value, { ...options, device: device.id })
+      .then(result => ({ device, success: true, result }))
+      .catch(error => ({ device, success: false, error }));
+  });
+
+  return Promise.all(promises);
+}


### PR DESCRIPTION
## What

Refactors the CLI to support a full device-targeting hierarchy:

```
lumina on / off / status          → all devices
lumina bulb on / off              → all bulbs  
lumina bulb "Living Room" toggle  → specific device by name
```

## Planned Changes

- `src/cli/index.ts` — refactor `bulb` subcommand to accept `[name] [action]` argument order; add `--all` flag
- `config/devices.json` — local device registry/cache so scanning isn't required on every command
- Add `inquirer` dependency for interactive disambiguation when a name matches multiple devices

## Status

🚧 Draft — implementation in progress