### PR TITLE
feat: unify services with concurrent start command and fix isolated process executions

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "luminaa",
+  "name": "lumina",
   "version": "0.1.0",
   "private": true,
   "bin": {

--- a/package.json
+++ b/package.json
@@ -12,7 +12,10 @@
     "lint": "eslint",
     "cli": "npx tsx src/cli/index.ts",
     "whatsapp": "npx tsx src/integrations/whatsapp/index.ts",
-    "telegram": "npx tsx src/integrations/telegram/index.ts"
+    "telegram": "npx tsx src/integrations/telegram/index.ts",
+    "websocket": "npx tsx src/integrations/websocket/index.ts",
+    "cron": "npx tsx src/service/runner.ts",
+    "start:all": "npx concurrently -c \"bgBlue.bold,bgMagenta.bold,bgCyan.bold,bgGreen.bold\" \"npm run whatsapp\" \"npm run telegram\" \"npm run websocket\" \"npm run cron\""
   },
   "dependencies": {
     "@hapi/boom": "^10.0.1",

--- a/src/integrations/telegram/index.ts
+++ b/src/integrations/telegram/index.ts
@@ -73,3 +73,11 @@ export async function startTelegramBot() {
 
   console.log('Bot is running in long-polling mode...');
 }
+
+// Entry point — invoked when run directly
+if (require.main === module || process.argv[1]?.endsWith('telegram/index.ts')) {
+  startTelegramBot().catch((err) => {
+    console.error('[Telegram] Fatal startup error:', err);
+    process.exit(1);
+  });
+}

--- a/src/integrations/websocket/index.ts
+++ b/src/integrations/websocket/index.ts
@@ -93,3 +93,11 @@ export async function startWebSocketServer() {
     wss.close();
   });
 }
+
+// Entry point — invoked when run directly
+if (require.main === module || process.argv[1]?.endsWith('websocket/index.ts')) {
+  startWebSocketServer().catch((err) => {
+    console.error('[WebSocket] Fatal startup error:', err);
+    process.exit(1);
+  });
+}

--- a/src/service/runner.ts
+++ b/src/service/runner.ts
@@ -12,8 +12,9 @@ async function main() {
       console.error(`❌ Reload Error: ${message}`);
     });
   });
+  // Keep the process alive even if there are no cron tasks yet
+  setInterval(() => {}, 1000 * 60 * 60);
 
-  // Keep the process alive
   // node-cron tasks will keep the event loop alive, but we can also handle graceful shutdown
   process.on('SIGINT', () => {
     console.log('\n🛑 Stopping Cron Service...');


### PR DESCRIPTION
## Summary
This PR introduces a unified `start:all` script to seamlessly run all core application services (WhatsApp, Telegram, WebSocket, and Cron scheduler) simultaneously within a single terminal instance. It also fixes execution bugs where certain scripts failed to initialize when invoked directly via the CLI.

## Changes Included
- **Unified Startup:** Added a `start:all` command in `package.json` that uses `npx concurrently` to run all four services at once, complete with color-coded logging. 
- **Telegram & WebSocket Fixes:** Added direct-execution blocks to `src/integrations/telegram/index.ts` and `src/integrations/websocket/index.ts`. These services now correctly instantiate their servers/listeners rather than just exporting the initialization functions.
- **Cron Reliability:** Added a dummy `setInterval` to `src/service/runner.ts` to keep the node event loop alive. This prevents the cron scheduler (and subsequently concurrently) from prematurely crashing if `automations.json` is missing or empty on startup.

## How to Test
Run `npm run start:all`
